### PR TITLE
2.0.0 -- superagent 2 and 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A superagent plugin providing flexible, built-in caching.
 
+Now compatible with superagent `2.x` and `3.x`.
+
 # Contents
 
 * [Basic Usage](#basic-usage)
@@ -14,6 +16,7 @@ A superagent plugin providing flexible, built-in caching.
 * [Supported Caches](#supported-caches)
 * [API](#api)
 * [More Usage Examples](#more-usage-examples)
+* [Breaking Change History](#breaking-change-history)
 * [Release Notes](https://github.com/jpodwys/superagent-cache-plugin/releases)
 
 # Basic Usage
@@ -316,3 +319,12 @@ However, you can only get it when you pass 3 params to the callback's argument l
 * 1 param: the param will always be `response`
 * 2 params: the params will always be `err` and `response`
 * 3 params: the params will always be `err`, `response`, and `key`
+
+# Breaking Change History
+
+#### 2.0.0
+
+* Now compatible with superagent `2.x` and `3.x`
+* `.pruneParams` is now `.pruneQuery` for clarity
+* `.pruneOptions` is now `.pruneHeader` for clarity
+* The `resolve` function passed to `.then` no longer exposes the generated cache key like it did when using superagent `^1.3.0` with superagent-cache `^1.5.0` (but using `.end` still does)

--- a/README.md
+++ b/README.md
@@ -137,27 +137,6 @@ Same as superagent except that superagent's response object will be cached.
 
 Same as superagent except that the generated cache key will be automatically invalidated when these `HTTP` verbs are used.
 
-## .then(resolve, reject)
-
-In its [`1.3.0` release](https://github.com/visionmedia/superagent/releases/tag/v1.3.0), superagent added fake promise support in the form of a `.then()` chainable that accepts two functions. Before superagent `2.x`, this function does not return a real promise. Rather, it calls `.end()` internally and then decides which function (`resolve` or `reject`) to call. (superagent-cache-plugin does not yet support superagent `2.x`.)
-
-> Should work with [`superagent-promise`](https://github.com/lightsofapollo/superagent-promise), [`superagent-bluebird-promise`](https://github.com/KyleAMathews/superagent-bluebird-promise), and [`superagent-promise-plugin`](https://github.com/jomaxx/superagent-promise-plugin) (perhaps others as well).
-
-I've overwritten superagent's `.then()` so that the provided `resolve` function accepts the generate cache key as follows:
-
-```javascript
-superagent
-  .get(uri)
-  .use(superagentCache)
-  .then(function (response, key){
-    // handle response--key is available if desired
-  }, function (err){
-    // handle the error
-  }
-);
-
-```
-
 ## .end(callback ([err,] response [, key]))
 
 Same as superagent except it optionally exposes the key superagent-cache-plugin generates as the third param in the callback's argument list. See the [usage example](#end-callback-argument-list-options) for a more detailed explanation.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A superagent plugin providing flexible, built-in caching.
 
-Currently compatible with superagent `1.x`.
-
 # Contents
 
 * [Basic Usage](#basic-usage)

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ All options that can be passed to the `defaults` `require` param can be overwrit
 
 * responseProp
 * prune
-* pruneParams
-* pruneOptions
+* pruneQuery
+* pruneHeader
 * expiration
 * cacheWhenEmpty
 * doQuery
@@ -193,9 +193,9 @@ superagent
 );
 ```
 
-## .pruneParams(params)
+## .pruneQuery(params)
 
-In the event that you need certain query params to execute a query but cannot have those params as part of your cache key (useful when security or time-related params are sent), use `.pruneParams()` to remove those properties. Pass `.pruneParams()` an array containing the param keys you want omitted from the cache key.
+In the event that you need certain query params to execute a query but cannot have those params as part of your cache key (useful when security or time-related params are sent), use `.pruneQuery()` to remove those properties. Pass `.pruneQuery()` an array containing the param keys you want omitted from the cache key.
 
 #### Arguments
 
@@ -210,16 +210,16 @@ superagent
   .get(uri)
   .use(superagentCache)
   .query(query)
-  .pruneParams(['token'])
+  .pruneQuery(['token'])
   .end(function (error, response){
     // handle response
   }
 );
 ```
 
-## .pruneOptions(options)
+## .pruneHeader(options)
 
-This function works just like the `.pruneParams()` funciton except that it modifies the arguments passed to the `.set()` chainable method (headers) rather than those passed to the `.query()` chainable method.
+This function works just like the `.pruneQuery()` funciton except that it modifies the arguments passed to the `.set()` chainable method (headers) rather than those passed to the `.query()` chainable method.
 
 #### Arguments
 
@@ -234,7 +234,7 @@ superagent
   .get(uri)
   .use(superagentCache)
   .set(options)
-  .pruneOptions(['token'])
+  .pruneHeader(['token'])
   .end(function (error, response){
     // handle response
   }

--- a/index.js
+++ b/index.js
@@ -8,14 +8,13 @@ var utils = require('./utils');
  */
 module.exports = function(cache, defaults){
   var self = this;
-  self.cache = cache;
-  self.defaults = defaults || {};
+  var supportedMethods = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'];
+  var cacheableMethods = ['GET', 'HEAD'];
+  this.cache = cache;
+  this.defaults = defaults || {};
 
   return function (Request) {
-    var props = utils.cloneObject(self.defaults);
-    props = utils.resetProps(props);
-    var supportedMethods = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'];
-    var cacheableMethods = ['GET', 'HEAD'];
+    var props = utils.resetProps(self.defaults);
 
     /**
      * Whether to execute an http query if the cache does not have the generated key
@@ -90,24 +89,11 @@ module.exports = function(cache, defaults){
     }
 
     /**
-     * Overwrites superagent's fake promise support and adds the generated cache key
-     * Only applies if Request.promise is not set
-     * Fixes Request isse: https://github.com/jpodwys/superagent-cache/issues/38
-     */
-    if(!Request.promise){
-      Request.then = function(fulfill, reject){
-        return Request.end(function (err, response, key) {
-          err ? reject(err) : fulfill(response, key);
-        });
-      }
-    }
-
-    /**
      * Save the exisitng .end() value ("namespaced" in case of other plugins)
      * so that we can provide our customized .end() and then call through to
      * the underlying implementation.
      */
-    Request._cache_originalEnd = Request.end;
+    var end = Request.end;
 
     /**
      * Execute all caching and http logic
@@ -126,7 +112,7 @@ module.exports = function(cache, defaults){
             }
             else{
               if(props.doQuery){
-                _Request._cache_originalEnd(function (err, response){
+                end.call(Request, function (err, response){
                   if(err){
                     return utils.callbackExecutor(cb, err, response, key);
                   }
@@ -159,7 +145,7 @@ module.exports = function(cache, defaults){
           });
         }
         else{
-          Request._cache_originalEnd(function (err, response){
+          end.call(Request, function (err, response){
             if(err){
               return utils.callbackExecutor(cb, err, response, key);
             }
@@ -174,7 +160,7 @@ module.exports = function(cache, defaults){
         }
       }
       else{
-        Request._cache_originalEnd(function (err, response){
+        end.call(Request, function (err, response){
           return utils.callbackExecutor(cb, err, response, undefined);
         });
       }

--- a/index.js
+++ b/index.js
@@ -27,19 +27,19 @@ module.exports = function(cache, defaults){
 
     /**
      * Remove the given params from the query object after executing an http query and before generating a cache key
-     * @param {array of strings} pruneParams
+     * @param {array of strings} pruneQuery
      */
-    Request.pruneParams = function(pruneParams){
-      props.pruneParams = pruneParams;
+    Request.pruneQuery = function(pruneQuery){
+      props.pruneQuery = pruneQuery;
       return Request;
     }
 
     /**
      * Remove the given options from the headers object after executing an http query and before generating a cache key
-     * @param {boolean} pruneOptions
+     * @param {boolean} pruneHeader
      */
-    Request.pruneOptions = function(pruneOptions){
-      props.pruneOptions = pruneOptions;
+    Request.pruneHeader = function(pruneHeader){
+      props.pruneHeader = pruneHeader;
       return Request;
     }
 
@@ -71,7 +71,7 @@ module.exports = function(cache, defaults){
     }
 
     /**
-     * Whether to cache superagent's http response object when it "empty"--especially useful with .prune and .pruneParams
+     * Whether to cache superagent's http response object when it "empty"--especially useful with .prune and .pruneQuery
      * @param {boolean} cacheWhenEmpty
      */
     Request.cacheWhenEmpty = function(cacheWhenEmpty){

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "superagent-cache-plugin",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Superagent with flexible built-in caching.",
   "main": "index.js",
   "devDependencies": {
-    "superagent": "1.7.2",
+    "superagent": "3.x",
     "cache-service-cache-module": "1.x",
     "es6-promise": "3.0.2",
     "expect": "1.6.0",

--- a/test/server/spec.js
+++ b/test/server/spec.js
@@ -36,11 +36,11 @@ app.get('/false', function(req, res){
 });
 
 app.get('/params', function(req, res){
-  res.send(200, {pruneParams: req.query.pruneParams, otherParams: req.query.otherParams});
+  res.send(200, {pruneQuery: req.query.pruneQuery, otherParams: req.query.otherParams});
 });
 
 app.get('/options', function(req, res){
-  res.send(200, {pruneOptions: req.get('pruneOptions'), otherOptions: req.get('otherOptions')});
+  res.send(200, {pruneHeader: req.get('pruneHeader'), otherOptions: req.get('otherOptions')});
 });
 
 app.get('/four', function(req, res){
@@ -154,69 +154,69 @@ describe('superagentCache', function(){
       );
     });
 
-    it('.get() .query(object) .pruneParams() .end() should query with all params but create a key without the indicated params', function (done) {
+    it('.get() .query(object) .pruneQuery() .end() should query with all params but create a key without the indicated params', function (done) {
       superagent
         .get('localhost:3000/params')
         .use(superagentCache)
-        .query({pruneParams: true, otherParams: false})
-        .pruneParams(['pruneParams'])
+        .query({pruneQuery: true, otherParams: false})
+        .pruneQuery(['pruneQuery'])
         .end(function (err, response, key){
-          expect(response.body.pruneParams).toBe('true');
+          expect(response.body.pruneQuery).toBe('true');
           expect(response.body.otherParams).toBe('false');
-          expect(key.indexOf('pruneParams')).toBe(-1);
+          expect(key.indexOf('pruneQuery')).toBe(-1);
           expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
           done();
         }
       );
     });
 
-    it('.get() .query(string&string) .pruneParams() .end() should query with all params but create a key without the indicated params', function (done) {
+    it('.get() .query(string&string) .pruneQuery() .end() should query with all params but create a key without the indicated params', function (done) {
       superagent
         .get('localhost:3000/params')
         .use(superagentCache)
-        .query('pruneParams=true&otherParams=false')
-        .pruneParams(['pruneParams'])
+        .query('pruneQuery=true&otherParams=false')
+        .pruneQuery(['pruneQuery'])
         .end(function (err, response, key){
-          expect(response.body.pruneParams).toBe('true');
+          expect(response.body.pruneQuery).toBe('true');
           expect(response.body.otherParams).toBe('false');
-          expect(key.indexOf('pruneParams')).toBe(-1);
+          expect(key.indexOf('pruneQuery')).toBe(-1);
           expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
           done();
         }
       );
     });
 
-    it('.get() .query(string) .query(string) .pruneParams() .end() should query with all params but create a key without the indicated params', function (done) {
+    it('.get() .query(string) .query(string) .pruneQuery() .end() should query with all params but create a key without the indicated params', function (done) {
       superagent
         .get('localhost:3000/params')
         .use(superagentCache)
-        .query('pruneParams=true')
+        .query('pruneQuery=true')
         .query('otherParams=false')
-        .pruneParams(['pruneParams'])
+        .pruneQuery(['pruneQuery'])
         .end(function (err, response, key){
-          expect(response.body.pruneParams).toBe('true');
+          expect(response.body.pruneQuery).toBe('true');
           expect(response.body.otherParams).toBe('false');
-          expect(key.indexOf('pruneParams')).toBe(-1);
+          expect(key.indexOf('pruneQuery')).toBe(-1);
           expect(key.indexOf('otherParams')).toBeGreaterThan(-1);
           done();
         }
       )
     });
 
-    it('.get() .pruneOptions() .end() should query with all options but create a key without the indicated options', function (done) {
+    it('.get() .pruneHeader() .end() should query with all options but create a key without the indicated options', function (done) {
       superagent
         .get('localhost:3000/options')
         .use(superagentCache)
-        .set({pruneOptions: true, otherOptions: false})
-        .pruneOptions(['pruneOptions'])
+        .set({pruneHeader: true, otherOptions: false})
+        .pruneHeader(['pruneHeader'])
         .end(function (err, response, key){
           //console.log(key);
-          expect(response.body.pruneOptions).toBe('true');
+          expect(response.body.pruneHeader).toBe('true');
           expect(response.body.otherOptions).toBe('false');
           //Before superagent 1.7.0, superagent converts headers to lower case. To be backwards compatible,
           //I check for lower as well as the upper case versions of the headers sent above
-          expect(key.indexOf('pruneoptions')).toBe(-1);
-          expect(key.indexOf('pruneOptions')).toBe(-1);
+          expect(key.indexOf('pruneHeader')).toBe(-1);
+          expect(key.indexOf('pruneHeader')).toBe(-1);
           var lowerOtherOptions = key.indexOf('otheroptions');
           var upperOtherOptions = key.indexOf('otherOptions');
           var otherOptionsIsPresent = (lowerOtherOptions > -1 || upperOtherOptions > -1);

--- a/utils.js
+++ b/utils.js
@@ -10,9 +10,9 @@ module.exports = {
     var cleanOptions = null;
     var params = this.getQueryParams(req);
     var options = this.getHeaderOptions(req);
-    if(props.pruneParams || props.pruneOptions){
-      cleanParams = (props.pruneParams) ? this.pruneObj(this.cloneObject(params), props.pruneParams) : params;
-      cleanOptions = (props.pruneOptions) ? this.pruneObj(this.cloneObject(options), props.pruneOptions, true) : options;
+    if(props.pruneQuery || props.pruneHeader){
+      cleanParams = (props.pruneQuery) ? this.pruneObj(this.cloneObject(params), props.pruneQuery) : params;
+      cleanOptions = (props.pruneHeader) ? this.pruneObj(this.cloneObject(options), props.pruneHeader, true) : options;
     }
     return JSON.stringify({
       method: req.method,
@@ -164,8 +164,8 @@ module.exports = {
       doQuery: (typeof d.doQuery === 'boolean') ? d.doQuery : true,
       cacheWhenEmpty: (typeof d.cacheWhenEmpty === 'boolean') ? d.cacheWhenEmpty : true,
       prune: d.prune,
-      pruneParams: d.pruneParams,
-      pruneOptions: d.pruneOptions,
+      pruneQuery: d.pruneQuery,
+      pruneHeader: d.pruneHeader,
       responseProp: d.responseProp,
       expiration: d.expiration,
       forceUpdate: d.forceUpdate,


### PR DESCRIPTION
#### Changes

* `.pruneParams` -> `.pruneQuery` for clarity
* `.pruneOptions` -> `.pruneHeader` for clarity
* No longer wrapping `.then` since superagent uses real promises since `2.x`. As a result, the `resolve` function passed to `.then` no longer exposes the generated cache key like it did when using superagent `^1.3.0` with superagent-cache-plugin (but using `.end` still does)