### PR TITLE
Respect Server response Cache related headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Require and instantiate superagent-cache-plugin as follows to get the [default c
 ```javascript
 // Require and instantiate a cache module
 var cacheModule = require('cache-service-cache-module');
-var cache = new cacheModule({storage: 'session', defaultExpiration: 60});
+var cache = new cacheModule({storage: 'session'});
 
 // Require superagent-cache-plugin and pass your cache module
 var superagentCache = require('superagent-cache-plugin')(cache);
@@ -100,6 +100,22 @@ All options that can be passed to the `defaults` `require` param can be overwrit
 * cacheWhenEmpty
 * doQuery
 * forceUpdate
+
+# The `Cache-Control` request/response headers related behavior
+
+* Setting the request header `Cache-Control: maxe-age=X` is an alternative to the `.expiration(X)` API method call.
+* Setting the request header `Cache-Control: only-if-cached` is an alternative to the `.doQuery(false)` API method call.
+* Setting the `Cache-Control`request header value to one of `maxe-age=0`, `no-cache`, `no-store`switches of caching of the response.
+
+**NOTE** The plugin respects the server response cache related headers (`Cache-Control`, `Pragma: no-cache`, `Expires`) and calculates proper TTL for cached responses, with the respect to following:
+
+* When the `expiration` option is unspecified, the default behavior will be no caching, unless the server response `Cache-Control` header specifies otherwise.
+* The `expiration=0` specified in options will switch off caching for any request, even when the server specifies that the response is cacheable and provides non-zero TTL via eg. the `Cache-Control: max-age=X` header.
+* The non-zero `expiration` option value will narrow down any of TTL value specified via server response `Cache-Control` header.
+* When the `expiration` option value is greater than the TTL specified via server response `Cache-Control` header, the later wins.
+
+## `ETag` and `Last-Modified` support.
+The `ETag` and `Last-Modified` related cache behavior is supported with sending the associated request headers for cached response revalidation and proper handling of the `304 Not Modified` response, which results in serving the cached response instead `304` one.
 
 # Supported Caches
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ All options that can be passed to the `defaults` `require` param can be overwrit
 * cacheWhenEmpty
 * doQuery
 * forceUpdate
+* bypassHeaders
 
 # The `Cache-Control` request/response headers related behavior
 
@@ -295,6 +296,43 @@ Tells `superagent-cache-plugin` to perform an ajax call regardless of whether th
 #### Arguments
 
 * bool: boolean, default: false
+
+## .bypassHeaders(headerNames)
+
+Tells `superagent-cache-plugin` to copy given headers from the current executing request to the response.
+This is useful for eg. some correlation ID, which binds a request with a response and could be an issue when returning a cached response.
+**Note** Bypassed headers are copied only to cached responses.
+
+#### Arguments
+
+* headerNames: string or array of strings
+
+#### Example
+
+```javascript
+//the superagent query will be executed with all headers
+//but the key used to store the superagent response will be generated without the 'bypassHeaders' header keys
+//and the response will have those keys set to the values from the request headers, when served from a cache.
+var correlationId = 0;
+superagent
+  .get(uri)
+  .use(superagentCache)
+  .expiration(1)
+  .bypassHeaders(['x-correlation-id'])
+  .set('x-correlation-id', correlationId++)
+  .end(function (error, response){
+    superagent
+      .get(uri)
+      .use(superagentCache)
+      .bypassHeaders(['x-correlation-id'])
+      .set('x-correlation-id', correlationId++)
+      .end(function (error, response){
+        expect(response.header['x-cache']).toBe('HIT');
+        expect(response.header['x-correlation-id']).toBe(1);
+      });
+  }
+);
+```
 
 ## superagentCache.cache
 

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = function(cache, defaults){
     var cachedEntry;
 
     // Special handling for the '304 Not Modified' case, which will only come out
-    // in case of the server responses with 'ETag' and 'Modification-Date'.
+    // in case of server responses with 'ETag' and/or 'Last-Modified' headers.
     Request.on('response', function (res) {
       if (res.status === 304 && cachedEntry) {
         res.status = cachedEntry.response.status;

--- a/index.js
+++ b/index.js
@@ -150,8 +150,8 @@ module.exports = function(cache, defaults){
                     if ((0 !== props.expiration) && (!utils.isEmpty(response) || props.cacheWhenEmpty)) {
                       if (policy.storable() && policy.timeToLive() > 0) {
                         const expiration = props.expiration
-                          ? Math.min(props.expiration, Math.round(policy.timeToLive()/1000, 0))
-                          :  Math.round(policy.timeToLive()/1000, 0);
+                          ? Math.min(props.expiration, Math.round(policy.timeToLive() / 1000))
+                          :  Math.round(policy.timeToLive() / 1000);
                         const entry = { policy: policy.toObject() , response: response };
                         cache.set(key, entry, expiration , function () {
                           return utils.callbackExecutor(cb, err, response, key);

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "plugin",
     "browser",
     "node"
-  ]
+  ],
+  "dependencies": {
+    "http-cache-semantics": "~3.7.3"
+  }
 }

--- a/test/server/spec.js
+++ b/test/server/spec.js
@@ -534,7 +534,7 @@ describe('superagentCache', function() {
                 done();
               }
             );
-          }, 1000);
+          }, 1200);
         }
       );
     });

--- a/test/server/spec.js
+++ b/test/server/spec.js
@@ -254,7 +254,7 @@ describe('superagentCache', function() {
         .use(superagentCache)
         .doQuery(false)
         .end(function (err, response, key){
-          expect(response).toBe(null);
+          expect(response.status).toBe(504);
           done();
         }
       )
@@ -432,14 +432,14 @@ describe('superagentCache', function() {
       done();
     });
 
-    it('Should return null response when \'only-if-cached\' is set in the request header.', function (done) {
+    it('Should return 504 response when \'only-if-cached\' is set in the request header.', function (done) {
       superagentCache = superagentCacheModule(cache, {doQuery: true, expiration: 1});
       superagent
         .get('localhost:3000/one')
         .use(superagentCache)
         .set('cache-control', 'only-if-cached')
         .end(function (err, response, key){
-          expect(response).toBe(null);
+          expect(response.status).toBe(504);
           done();
         }
       );
@@ -451,6 +451,7 @@ describe('superagentCache', function() {
         .get('localhost:3000/one')
         .use(superagentCache)
         .end(function (err, response, key){
+          expect(response.status).toBe(504);
           cache.get(key, function (err, response) {
             expect(response).toBe(null);
             done();
@@ -639,7 +640,7 @@ describe('superagentCache', function() {
                       done();
                     }
                   );
-                }, 100);
+                }, 50);
               }
             );
           }, 990);

--- a/utils.js
+++ b/utils.js
@@ -11,6 +11,7 @@ module.exports = {
     var cleanOptions = null;
     var params = this.getQueryParams(req);
     var options = this.getHeaderOptions(req);
+    props.pruneHeader = ['if-none-match', 'if-modified-since'].concat(props.pruneHeader || []);
     if(props.pruneQuery || props.pruneHeader){
       cleanParams = (props.pruneQuery) ? this.pruneObj(this.cloneObject(params), props.pruneQuery) : params;
       cleanOptions = (props.pruneHeader) ? this.pruneObj(this.cloneObject(options), props.pruneHeader, true) : options;
@@ -47,23 +48,23 @@ module.exports = {
    * Find and extract headers
    * @param {object} reg
    */
-  getHeaderOptions: function(_req){
+  getHeaderOptions: function(req){
     // I have to remove the User-Agent header ever since superagent 1.7.0
     // The cache-control header must also be removed.
     // Clone the request first, as we don't want to remove the headers from the original one, do we?
-    const req = JSON.parse(JSON.stringify(_req));
+    const _req = req ? JSON.parse(JSON.stringify(req)) : req;
     const headersToPrune = ['user-agent', 'cache-control'];
-    if(req && req.headers){
-      return this.pruneObj(req.headers, headersToPrune);
+    if(_req && _req.headers){
+      return this.pruneObj(_req.headers, headersToPrune);
     }
-    else if(req && req._header){
-      return this.pruneObj(req._header, headersToPrune);
+    else if(_req && _req._header){
+      return this.pruneObj(_req._header, headersToPrune);
     }
-    else if(req && req.req && req.req._headers){
-      return this.pruneObj(req.req._headers, headersToPrune);
+    else if(_req && _req.req && _req.req._headers){
+      return this.pruneObj(_req.req._headers, headersToPrune);
     }
-    else if(req && req.header){
-      return this.pruneObj(req.header, headersToPrune);
+    else if(_req && _req.header){
+      return this.pruneObj(_req.header, headersToPrune);
     }
     return null;
   },
@@ -132,13 +133,17 @@ module.exports = {
 
   /**
    * Simplify superagent's http response object
-   * @param {object} r
+   * @param {object} r - The response.
+   * @param {object} Request - The superagent's Request instance.
+   * @param {object} props  - The request properties.
    */
-  gutResponse: function(r){
+  gutResponse: function(r, Request, props){
     var newResponse = {};
+    newResponse.req = Request.toJSON();
     newResponse.body = r.body;
     newResponse.text = r.text;
-    newResponse.headers = r.headers;
+    newResponse.header = r.header;
+    newResponse.headers = r.header;
     newResponse.statusCode = r.statusCode;
     newResponse.status = r.status;
     newResponse.ok = r.ok;
@@ -182,7 +187,8 @@ module.exports = {
       expiration: d.expiration,
       forceUpdate: d.forceUpdate,
       preventDuplicateCalls: d.preventDuplicateCalls,
-      backgroundRefresh: d.backgroundRefresh
+      backgroundRefresh: d.backgroundRefresh,
+      bypassHeaders: d.bypassHeaders
     };
   },
 
@@ -192,8 +198,22 @@ module.exports = {
    * @param {object} err
    * @param {object} response
    * @param {string} key
+   * @param {object} [Request] - Superagent Request instance. When provided it will emit the events.
+   * @param {object} props  - The request internal properties.
    */
-  callbackExecutor: function(cb, err, response, key){
+  callbackExecutor: function(cb, err, response, key, Request){
+    if (response) {
+      // Superagent response should bear only the 'header' attribute, this was only needed for the policy.
+      delete response.headers;
+      if (Request) {
+        Request.emit('request', Request);
+        if (err) {
+          Request.emit('error', err);
+        } else {
+          Request.emit('response', response);
+        }
+      }
+    }
     if(cb.length === 1){
       cb(response);
     }
@@ -213,10 +233,17 @@ module.exports = {
    * @param {object} props  - The request-basis properties, which affect cache behavior.
    * @returns {object} The modified properties.
    */
-  handleReqCacheHeaders: function(req, props) {
+  handleReqCacheHeaders: function (req, props) {
     const cacheControl = req.get('cache-control');
-    if (typeof cacheControl === 'string' && cacheControl.toLowerCase().indexOf('only-if-cached') !== -1) {
-      props.doQuery = false;
+    if (typeof cacheControl === 'string') {
+      if (cacheControl.toLowerCase().indexOf('only-if-cached') !== -1) {
+        props.doQuery = false;
+      }
+      // the expiration can also be set via the Request header.
+      const maxAgeMatch = cacheControl.toLowerCase().match(/^(.*max-age=)(\d*).*$/);
+      if (maxAgeMatch) {
+        props.expiration = parseInt(maxAgeMatch[2]);
+      }
     }
     // We cheat the policy a bit here, giving the request instead of response (we don't have it at this stage),
     // as we want to parse the request headers for the caching control related values,
@@ -227,5 +254,65 @@ module.exports = {
     // The legacy method 'expiration()' will set the policy TTL value via the Cache-Control max-age value,
     // so no conflicts here.
     props.expiration = policy.storable() ? Math.round(policy.timeToLive() / 1000) : 0;
+  },
+
+  /**
+   * Returns the `expiration` (TTL) value calculated as a minimum of the `props.expiration` and `policy.timeToLive`.
+   * The resulting value is multiplied by `2`due to enable further handling of the stale cache entries,
+   * (when the policy allows for that).
+   * The resulting value is to be used for underlying cache implementation.
+   *
+   * @param {object} props  - The request-basis properties, which affect cache behavior.
+   * @param {object} policy - The cache policy.
+   * @returns {number} The expiration (TTL) time in seconds.
+   */
+  getExpiration: function (props, policy) {
+    return props.expiration
+      ? Math.min(props.expiration * 2, Math.round(policy.timeToLive() * 2 / 1000))
+      :  Math.round(policy.timeToLive() * 2 / 1000);
+  },
+
+  /**
+   * Sets the response header value.
+   *
+   * @param {object} response - The response instance.
+   * @param {string} name     - The header name.
+   * @param {string} value    - The header value.
+   * @returns {object} The incoming modified response.
+   */
+  setResponseHeader: function (response, name, value) {
+    // both need to be checked as someone could do strange things with 'prune' or 'responseProp'.
+    if (response) {
+      if (response.header) {
+        response.header[name] = value;
+      }
+      if (response.headers) {
+        response.headers[name] = value;
+      }
+    }
+    return response;
+  },
+
+  /**
+   * Copies the header values declared with the `bypassHeaders` option from current request
+   * to a cached response headers and its bound request headers.
+   *
+   * @param {object} response - The response instance.
+   * @param {object} req      - The request object.
+   * @param {object} props  - The request-basis properties, which affect cache behavior.
+   * @returns {object} The incoming modified response.
+   */
+  copyBypassHeaders: function (response, req, props) {
+    const self = this;
+    if (props.bypassHeaders && props.bypassHeaders.forEach) {
+      props.bypassHeaders.forEach(function (name) {
+        const value = req.get(name);
+        self.setResponseHeader(response, name, value);
+        if (response.req && response.req.headers) {
+          response.req.headers[name] = value;
+        }
+      });
+    }
+    return response;
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -52,7 +52,7 @@ module.exports = {
     // The cache-control header must also be removed.
     // Clone the request first, as we don't want to remove the headers from the original one, do we?
     const req = JSON.parse(JSON.stringify(_req));
-    const headersToPrune = ['User-Agent', 'user-agent', 'Cache-Control', 'cache-control'];
+    const headersToPrune = ['user-agent', 'cache-control'];
     if(req && req.headers){
       return this.pruneObj(req.headers, headersToPrune);
     }
@@ -116,13 +116,17 @@ module.exports = {
    * @param {boolean} isOptions
    */
   pruneObj: function(obj, props, isOptions){
-    for(var i = 0; i < props.length; i++){
-      var prop = props[i];
-      if(isOptions){
-        delete obj[prop.toLowerCase()];
+    const lowerCasedProps = props.map(function (item) {
+      return item.toLowerCase();
+    });
+    Object.keys(obj).forEach(function (key) {
+      if (lowerCasedProps.indexOf(key.toLowerCase()) !== -1) {
+        if(isOptions){
+          delete obj[key.toLowerCase()];
+        }
+        delete obj[key];
       }
-      delete obj[prop];
-    }
+    });
     return obj;
   },
 

--- a/utils.js
+++ b/utils.js
@@ -11,7 +11,11 @@ module.exports = {
     var cleanOptions = null;
     var params = this.getQueryParams(req);
     var options = this.getHeaderOptions(req);
-    props.pruneHeader = ['if-none-match', 'if-modified-since'].concat(props.pruneHeader || []);
+    // prune headers together with revalidation headers added internally by superagent
+    // and optional 'bypassHeaders' which are likely changing per request and should not
+    // be used to calculate the cache key.
+    props.pruneHeader = ['if-none-match', 'if-modified-since']
+      .concat(props.pruneHeader || [], props.bypassHeaders || []);
     if(props.pruneQuery || props.pruneHeader){
       cleanParams = (props.pruneQuery) ? this.pruneObj(this.cloneObject(params), props.pruneQuery) : params;
       cleanOptions = (props.pruneHeader) ? this.pruneObj(this.cloneObject(options), props.pruneHeader, true) : options;

--- a/utils.js
+++ b/utils.js
@@ -222,6 +222,6 @@ module.exports = {
     // Note: The default 'policy.timeToLive()' is '0' (means when there's no Expires or max-age specified).
     // The legacy method 'expiration()' will set the policy TTL value via the Cache-Control max-age value,
     // so no conflicts here.
-    props.expiration = policy.storable() ? Math.round(policy.timeToLive()/1000, 0) : 0;
+    props.expiration = policy.storable() ? Math.round(policy.timeToLive() / 1000) : 0;
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -241,7 +241,7 @@ module.exports = {
       }
       // the expiration can also be set via the Request header.
       const maxAgeMatch = cacheControl.toLowerCase().match(/^(.*max-age=)(\d*).*$/);
-      if (maxAgeMatch) {
+      if (maxAgeMatch && maxAgeMatch.length > 2 && maxAgeMatch[2] !== '') {
         props.expiration = parseInt(maxAgeMatch[2]);
       }
     }
@@ -267,9 +267,7 @@ module.exports = {
    * @returns {number} The expiration (TTL) time in seconds.
    */
   getExpiration: function (props, policy) {
-    return props.expiration
-      ? Math.min(props.expiration * 2, Math.round(policy.timeToLive() * 2 / 1000))
-      :  Math.round(policy.timeToLive() * 2 / 1000);
+    return Math.min(props.expiration * 2 || Number.MAX_VALUE, Math.round(policy.timeToLive() * 2 / 1000));
   },
 
   /**


### PR DESCRIPTION
- done with the usage of the opinionated https://www.npmjs.com/package/http-cache-semantics
- adopted tests
- additional test cases
- support for client request cache related headers
- README.md updated