### PR TITLE
Add support for handling querystring array parameters

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -72,7 +72,11 @@ module.exports = {
         var kvArray = str.split('&');
         for(var j = 0; j < kvArray.length; j++){
           var kvString = kvArray[j].split('=');
-          obj[kvString[0]] = kvString[1];
+          if(obj[kvString[0]]){
+            obj[kvString[0]] = obj[kvString[0]] + ',' + kvString[1];
+          }else{
+            obj[kvString[0]] = kvString[1];
+          }
         }
       }
       return obj;
@@ -94,7 +98,11 @@ module.exports = {
       var kvArray = str.split('&');
       for(var i = 0; i < kvArray.length; i++){
         var kvString = kvArray[i].split('=');
-        obj[kvString[0]] = kvString[1];
+        if(obj[kvString[0]]){
+          obj[kvString[0]] = obj[kvString[0]] + ',' + kvString[1];
+        }else{
+          obj[kvString[0]] = kvString[1];
+        }
       }
       return obj;
     }


### PR DESCRIPTION
#13 

It is common to send arrays in the querystring as: "?colors[]=blue&colors[]=red".
However, the key generated for such a request only used the last assignment, so
the previous querystring would have a key with:  

`{..., params: {..., 'colors[]': 'red'}}`

This caused false cache hits with incorrect responses, since
querystrings like "?colors[]=red" and "?colors[]=green&colors[]=yellow&colors[]=red"
would all generate the same cache key as the original querystring.

This commit fixes that by changing utils.arrayToObj to append multiple
querystring values with the same key into a single comma-delimited string. The
example querystrings above would generate the following key parts:

"?colors[]=blue&colors[]=red" -> 'colors[]': 'blue,red'
"?colors[]=red" -> 'colors[]': 'red'
"?colors[]=green&colors[]=yellow&colors[]=red" -> 'colors[]': 'green,yellow,red'

This is good enough for the intended purpose, but if the key is JSON.parse'd in,
say, the callback for .end(), it will remain a comma-delimited string and not be
converted into an array. Since I don't know whether this is desirable behavior,
I implemented the simpler string-based solution.